### PR TITLE
Bugfix for the DCA files

### DIFF
--- a/src/Resources/contao/templates/internal/efg_internal_dca_formdata.html5
+++ b/src/Resources/contao/templates/internal/efg_internal_dca_formdata.html5
@@ -471,7 +471,7 @@ endforeach;	?>
 endforeach; ?>),
 <?php if ($this->arrForm['key'] != 'feedback'): ?>
 		'formFilterKey'              => 'form',
-		'formFilterValue'            => '<?php echo $this->arrForm['title']; ?>'
+		'formFilterValue'            => '<?php echo \str_replace("'", "\'", $this->arrForm['title']); ?>'
 <?php endif; ?>
 	)
 );


### PR DESCRIPTION
Fix a problem where a form name like "My'Form" breaks the dca file, because the " ' " wasn't encoded.